### PR TITLE
Add due dates, overdue/alarm commands, and YAML config 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ with `done`, `delete`, `move`, and `due` commands.
 ## Configuration
 
 Optional YAML config. `todo` looks for it at `$TODO_PATH` if set, otherwise
-`$HOME/.config/todo/.todo`. If the file is missing or malformed, built-in
-defaults apply.
+`$HOME/.todo/config.yaml` (same directory as your todos). If the file is
+missing or malformed, built-in defaults apply.
 
 ```yaml
 general:
@@ -206,7 +206,8 @@ align under the text column so the table stays readable.
 ## Storage
 
 Todos are stored as JSON in `~/.todo/todos.json`. No database required. The
-optional config file lives separately (see [Configuration](#configuration)).
+optional config file lives in the same directory
+(see [Configuration](#configuration)).
 
 ## Shell Completion
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # todo
 
-A fast, minimal terminal todo app with nested spaces (namespaces) written in Go.
+A fast, minimal terminal todo app with nested spaces (namespaces), due dates,
+and an alarm view for what's coming up soon — written in Go.
 
-Organize your todos into dot-separated spaces like `office.monday.morning` and browse them from the command line.
+Organize your todos into dot-separated spaces like `office.monday.morning`, give
+them natural-language due dates (`tomorrow 2pm`, `next monday`, `in 3h`), and
+browse them from the command line.
 
 ## Install
 
@@ -41,6 +44,12 @@ todo add -s office "Prepare meeting slides"
 
 # Spaces can be nested with dots
 todo add -s office.monday.morning "Review weekly report"
+
+# Add with a due date
+todo add "Call mom" -d "tomorrow 2pm"
+todo add "Ship feature" -d "2026-04-30 14:00" -s work
+todo add "Drink water" -d "in 2h"
+todo add "Weekly sync" -d "next monday"
 ```
 
 ### List todos
@@ -52,6 +61,10 @@ todo
 # Show todos in a specific space (includes children)
 todo office
 todo office.monday
+
+# Sort by due date (items without a due date fall to the bottom)
+todo --sort=due
+todo office -o due
 ```
 
 ### List all spaces
@@ -67,6 +80,66 @@ home (1)
 office (3)
   monday (2)
     morning (1)
+```
+
+### Due dates
+
+Set, change, or clear the due date of an existing todo:
+
+```bash
+todo due a1b2 "next friday"
+todo due a1b2 tomorrow 2pm
+todo due a1b2 2026-04-30 14:00
+todo due a1b2 --clear
+```
+
+Supported date expressions include absolute dates (`2026-04-30`,
+`2026-04-30 14:00`, `30.04.2026`), keywords (`today`, `tomorrow`, `tonight`,
+`yesterday`), weekday names (`monday`, `next friday`), bare times (`2pm`,
+`14:00` — bumps to tomorrow if already past), and relative durations
+(`in 2h`, `in 30 minutes`, `+3d`, `2h`).
+
+Due dates show up inline in every listing, colored by urgency:
+
+```
+  [43f4]  call mom       due tomorrow 14:00  2026-04-24 06:35
+  [5080]  drink water    due today 08:35     2026-04-24 06:35
+  [bfec]  send contract  overdue 1d ago      2026-04-24 06:35
+```
+
+### Overdue
+
+List active todos whose due date has already passed:
+
+```bash
+# Default space only
+todo overdue
+
+# All spaces
+todo overdue --all
+```
+
+### Alarm (upcoming + overdue)
+
+List todos that are overdue or due within a time window. The window defaults to
+`general.alarm_window` from the config (1h if unset), and can be overridden
+per-invocation:
+
+```bash
+todo alarm                  # defaults to the configured window
+todo alarm -w 30m           # anything due within the next 30 minutes (or overdue)
+todo alarm -s work          # scope to one space
+todo alarm -f plain         # machine-friendly one-per-line output, no colors
+```
+
+The `plain` format composes nicely with other tools:
+
+```bash
+# Send each alarm to notify-send (Linux)
+todo alarm -f plain | while read -r l; do notify-send "todo" "$l"; done
+
+# Cron: check every 5 minutes with a 30-minute lookahead
+*/5 * * * * todo alarm -f plain -w 30m
 ```
 
 ### Mark as done
@@ -92,13 +165,48 @@ todo delete a1b2
 todo delete a1b2 c3d4
 ```
 
+### Move todos
+
+Move one or more todos to a different space:
+
+```bash
+todo move a1b2 -s work
+todo move a1b2 c3d4 -s office.monday
+```
+
+### Rename a space
+
+Rename a space (and all its children):
+
+```bash
+# Renames office.* to work.*
+todo rename office work
+```
+
 ## Todo IDs
 
-Each todo gets a unique 4-character hex ID (e.g., `a1b2`, `f0e9`). Use these IDs with `done` and `delete` commands.
+Each todo gets a unique 4-character hex ID (e.g., `a1b2`, `f0e9`). Use these IDs
+with `done`, `delete`, `move`, and `due` commands.
+
+## Configuration
+
+Optional YAML config. `todo` looks for it at `$TODO_PATH` if set, otherwise
+`$HOME/.config/todo/.todo`. If the file is missing or malformed, built-in
+defaults apply.
+
+```yaml
+general:
+  line_width: 120     # wrap the text column to this many characters (default 120)
+  alarm_window: 1h    # default window for 'todo alarm'; accepts 30m, 1h, 1h30m, 2d, 1w
+```
+
+Long todo text wraps at the configured `line_width`; continuation lines
+align under the text column so the table stays readable.
 
 ## Storage
 
-Todos are stored as JSON in `~/.todo/todos.json`. No database required.
+Todos are stored as JSON in `~/.todo/todos.json`. No database required. The
+optional config file lives separately (see [Configuration](#configuration)).
 
 ## Shell Completion
 
@@ -117,7 +225,9 @@ Completions include subcommands, space names, and todo IDs with text previews.
 
 ## Colors
 
-Output is color-coded for readability. Colors are automatically disabled when piping output or when the `NO_COLOR` environment variable is set.
+Output is color-coded for readability (e.g., overdue todos in red, due-soon in
+yellow). Colors are automatically disabled when piping output or when the
+`NO_COLOR` environment variable is set.
 
 ## License
 

--- a/cmd/alarm.go
+++ b/cmd/alarm.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/elvisoric/todo/store"
+	"github.com/spf13/cobra"
+)
+
+var (
+	alarmWithin string
+	alarmFormat string
+	alarmSpace  string
+)
+
+var alarmCmd = &cobra.Command{
+	Use:   "alarm",
+	Short: "Print todos that are overdue or due within a window",
+	Long: `Print active todos that are overdue or due within a time window.
+Defaults the window to the configured general.alarm_window (1h if unset).
+
+Compose with other tools:
+  todo alarm                                 # pretty output in a terminal
+  todo alarm -f plain                        # one line per todo, no colors
+  todo alarm -f plain | while read -r l; do notify-send "todo" "$l"; done
+  */5 * * * * todo alarm -f plain -w 30m     # cron`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		window := getConfig().General.AlarmWindow
+		if alarmWithin != "" {
+			d, err := parseWindow(alarmWithin)
+			if err != nil {
+				return err
+			}
+			window = d
+		}
+		if window < 0 {
+			return fmt.Errorf("window must be non-negative")
+		}
+
+		s, err := store.Load()
+		if err != nil {
+			return err
+		}
+
+		now := time.Now()
+		cutoff := now.Add(window)
+		var hits []store.Todo
+		for _, t := range s.ActiveTodos() {
+			if t.DueAt == nil {
+				continue
+			}
+			if t.DueAt.After(cutoff) {
+				continue
+			}
+			if alarmSpace != "" && t.Namespace != alarmSpace {
+				continue
+			}
+			hits = append(hits, t)
+		}
+		sort.SliceStable(hits, func(i, j int) bool {
+			return hits[i].DueAt.Before(*hits[j].DueAt)
+		})
+
+		switch alarmFormat {
+		case "", "pretty":
+			if len(hits) == 0 {
+				fmt.Println(c(dim, "No alarms."))
+				return nil
+			}
+			showNS := alarmSpace == ""
+			renderList(todoRows(hits, showNS), getConfig().General.LineWidth)
+		case "plain":
+			for _, t := range hits {
+				label, _ := formatDue(*t.DueAt, now)
+				ns := ""
+				if alarmSpace == "" {
+					ns = t.Namespace + " "
+				}
+				fmt.Printf("[%s] %s%s (%s)\n", t.ID, ns, t.Text, label)
+			}
+		default:
+			return fmt.Errorf("unknown format %q (supported: pretty, plain)", alarmFormat)
+		}
+		return nil
+	},
+}
+
+func init() {
+	alarmCmd.Flags().StringVarP(&alarmWithin, "within", "w", "", "Window before due date to alarm on (e.g. 30m, 1h, 2d). Defaults to config.")
+	alarmCmd.Flags().StringVarP(&alarmFormat, "format", "f", "pretty", "Output format: pretty or plain")
+	alarmCmd.Flags().StringVarP(&alarmSpace, "space", "s", "", "Limit to a specific space (default: all spaces)")
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultLineWidth   = 120
+	defaultAlarmWindow = time.Hour
+)
+
+type Config struct {
+	General struct {
+		LineWidth   int           `yaml:"line_width"`
+		AlarmWindow time.Duration `yaml:"-"`
+	} `yaml:"general"`
+}
+
+type rawConfig struct {
+	General struct {
+		LineWidth   int    `yaml:"line_width"`
+		AlarmWindow string `yaml:"alarm_window"`
+	} `yaml:"general"`
+}
+
+var (
+	cfgOnce sync.Once
+	cfg     *Config
+)
+
+func configPath() string {
+	if p := os.Getenv("TODO_PATH"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".config", "todo", ".todo")
+}
+
+func getConfig() *Config {
+	cfgOnce.Do(func() {
+		cfg = loadConfig()
+	})
+	return cfg
+}
+
+func loadConfig() *Config {
+	c := &Config{}
+	c.General.LineWidth = defaultLineWidth
+	c.General.AlarmWindow = defaultAlarmWindow
+
+	path := configPath()
+	if path == "" {
+		return c
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return c // missing/unreadable config → defaults
+	}
+	var parsed rawConfig
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: invalid config at %s: %v\n", path, err)
+		return c
+	}
+	if parsed.General.LineWidth > 0 {
+		c.General.LineWidth = parsed.General.LineWidth
+	}
+	if s := strings.TrimSpace(parsed.General.AlarmWindow); s != "" {
+		if d, err := parseWindow(s); err == nil {
+			c.General.AlarmWindow = d
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: invalid alarm_window %q in %s: %v\n", s, path, err)
+		}
+	}
+	return c
+}
+
+func parseWindow(s string) (time.Duration, error) {
+	if d, err := time.ParseDuration(s); err == nil {
+		return d, nil
+	}
+	if d, ok := parseRelative(strings.ToLower(s)); ok {
+		return d, nil
+	}
+	return 0, fmt.Errorf("unrecognized duration %q (try forms like 1h, 30m, 1h30m, 2d, 1w)", s)
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -43,7 +43,7 @@ func configPath() string {
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".config", "todo", ".todo")
+	return filepath.Join(home, ".todo", "config.yaml")
 }
 
 func getConfig() *Config {

--- a/cmd/due.go
+++ b/cmd/due.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var weekdays = map[string]time.Weekday{
+	"sunday": time.Sunday, "sun": time.Sunday,
+	"monday": time.Monday, "mon": time.Monday,
+	"tuesday": time.Tuesday, "tue": time.Tuesday, "tues": time.Tuesday,
+	"wednesday": time.Wednesday, "wed": time.Wednesday,
+	"thursday": time.Thursday, "thu": time.Thursday, "thur": time.Thursday, "thurs": time.Thursday,
+	"friday": time.Friday, "fri": time.Friday,
+	"saturday": time.Saturday, "sat": time.Saturday,
+}
+
+var absoluteLayouts = []string{
+	"2006-01-02 15:04",
+	"2006-01-02T15:04",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+	"2006/01/02 15:04",
+	"2006/01/02",
+	"02.01.2006 15:04",
+	"02.01.2006",
+	"02/01/2006 15:04",
+	"02/01/2006",
+}
+
+var (
+	timeTokenRe  = regexp.MustCompile(`^\d{1,2}(:\d{2})?(am|pm|a|p)?$`)
+	relPlusRe    = regexp.MustCompile(`^\+(\d+)\s*(h|hr|hrs|hour|hours|m|min|mins|minute|minutes|d|day|days|w|wk|week|weeks)$`)
+	relWordRe    = regexp.MustCompile(`^in\s+(\d+)\s*(h|hr|hrs|hour|hours|m|min|mins|minute|minutes|d|day|days|w|wk|week|weeks)$`)
+	relCompactRe = regexp.MustCompile(`^(\d+)(h|m|d|w)$`)
+)
+
+// ParseDue parses a natural-language due date relative to now.
+func ParseDue(input string) (time.Time, error) {
+	return parseDueAt(input, time.Now())
+}
+
+func parseDueAt(input string, now time.Time) (time.Time, error) {
+	s := strings.ToLower(strings.TrimSpace(input))
+	if s == "" {
+		return time.Time{}, fmt.Errorf("empty due date")
+	}
+
+	for _, layout := range absoluteLayouts {
+		if t, err := time.ParseInLocation(layout, s, now.Location()); err == nil {
+			return t, nil
+		}
+	}
+
+	if d, ok := parseRelative(s); ok {
+		return now.Add(d), nil
+	}
+
+	forceNextWeek := false
+	if strings.HasPrefix(s, "next ") {
+		forceNextWeek = true
+		s = strings.TrimPrefix(s, "next ")
+	} else if strings.HasPrefix(s, "this ") {
+		s = strings.TrimPrefix(s, "this ")
+	}
+
+	dayPart, timePart := splitDayAndTime(strings.Fields(s))
+
+	var base time.Time
+	switch dayPart {
+	case "", "today":
+		base = startOfDay(now)
+	case "tomorrow", "tmrw", "tom":
+		base = startOfDay(now).AddDate(0, 0, 1)
+	case "tonight":
+		base = startOfDay(now)
+		if timePart == "" {
+			timePart = "20:00"
+		}
+	case "yesterday":
+		base = startOfDay(now).AddDate(0, 0, -1)
+	default:
+		if wd, ok := weekdays[dayPart]; ok {
+			base = nextWeekday(startOfDay(now), wd, forceNextWeek)
+		} else {
+			return time.Time{}, fmt.Errorf("unrecognized due date: %q", input)
+		}
+	}
+
+	if timePart != "" {
+		h, m, err := parseClock(timePart)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("unrecognized time %q in %q", timePart, input)
+		}
+		base = time.Date(base.Year(), base.Month(), base.Day(), h, m, 0, 0, base.Location())
+	}
+
+	// Bare time like "2pm" without a day: if already past, bump to tomorrow.
+	if dayPart == "" && timePart != "" && base.Before(now) {
+		base = base.AddDate(0, 0, 1)
+	}
+
+	return base, nil
+}
+
+func splitDayAndTime(parts []string) (day, timeStr string) {
+	for i, p := range parts {
+		if timeTokenRe.MatchString(p) {
+			day = strings.Join(parts[:i], " ")
+			timeStr = strings.Join(parts[i:], " ")
+			return
+		}
+		// Handle "2 pm" style: digits followed by "am"/"pm".
+		if isAllDigits(p) && i+1 < len(parts) && (parts[i+1] == "am" || parts[i+1] == "pm") {
+			day = strings.Join(parts[:i], " ")
+			timeStr = strings.Join(parts[i:], "")
+			return
+		}
+	}
+	day = strings.Join(parts, " ")
+	return
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func parseClock(s string) (int, int, error) {
+	s = strings.ReplaceAll(s, " ", "")
+	ampm := ""
+	switch {
+	case strings.HasSuffix(s, "pm"):
+		ampm = "pm"
+		s = strings.TrimSuffix(s, "pm")
+	case strings.HasSuffix(s, "am"):
+		ampm = "am"
+		s = strings.TrimSuffix(s, "am")
+	case strings.HasSuffix(s, "p"):
+		ampm = "pm"
+		s = strings.TrimSuffix(s, "p")
+	case strings.HasSuffix(s, "a"):
+		ampm = "am"
+		s = strings.TrimSuffix(s, "a")
+	}
+
+	var hour, min int
+	var err error
+	if idx := strings.Index(s, ":"); idx >= 0 {
+		hour, err = strconv.Atoi(s[:idx])
+		if err != nil {
+			return 0, 0, err
+		}
+		min, err = strconv.Atoi(s[idx+1:])
+		if err != nil {
+			return 0, 0, err
+		}
+	} else {
+		hour, err = strconv.Atoi(s)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
+
+	if ampm == "pm" && hour < 12 {
+		hour += 12
+	} else if ampm == "am" && hour == 12 {
+		hour = 0
+	}
+
+	if hour < 0 || hour > 23 || min < 0 || min > 59 {
+		return 0, 0, fmt.Errorf("invalid time")
+	}
+	return hour, min, nil
+}
+
+func parseRelative(s string) (time.Duration, bool) {
+	if m := relPlusRe.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return toDuration(n, m[2]), true
+	}
+	if m := relWordRe.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return toDuration(n, m[2]), true
+	}
+	if m := relCompactRe.FindStringSubmatch(s); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		return toDuration(n, m[2]), true
+	}
+	return 0, false
+}
+
+func toDuration(n int, unit string) time.Duration {
+	switch unit[0] {
+	case 'h':
+		return time.Duration(n) * time.Hour
+	case 'm':
+		return time.Duration(n) * time.Minute
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour
+	case 'w':
+		return time.Duration(n) * 7 * 24 * time.Hour
+	}
+	return 0
+}
+
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+func nextWeekday(from time.Time, target time.Weekday, forceNextWeek bool) time.Time {
+	diff := (int(target) - int(from.Weekday()) + 7) % 7
+	if diff == 0 && forceNextWeek {
+		diff = 7
+	}
+	return from.AddDate(0, 0, diff)
+}
+
+// formatDue returns a short human label and an ANSI color for the due date.
+func formatDue(due, now time.Time) (string, string) {
+	delta := due.Sub(now)
+	midnight := startOfDay(now)
+	dueDay := startOfDay(due)
+	daysDiff := int(dueDay.Sub(midnight).Hours() / 24)
+	hasTime := due.Hour() != 0 || due.Minute() != 0
+
+	if delta < 0 {
+		return "overdue " + humanDuration(-delta) + " ago", red
+	}
+
+	var label string
+	switch daysDiff {
+	case 0:
+		if hasTime {
+			label = "today " + due.Format("15:04")
+		} else {
+			label = "today"
+		}
+	case 1:
+		if hasTime {
+			label = "tomorrow " + due.Format("15:04")
+		} else {
+			label = "tomorrow"
+		}
+	default:
+		if daysDiff > 1 && daysDiff < 7 {
+			if hasTime {
+				label = due.Format("Mon 15:04")
+			} else {
+				label = due.Format("Mon")
+			}
+		} else if hasTime {
+			label = due.Format("2006-01-02 15:04")
+		} else {
+			label = due.Format("2006-01-02")
+		}
+	}
+
+	color := dim
+	if delta < 24*time.Hour {
+		color = yellow
+	}
+	if daysDiff == 0 && hasTime && delta < 2*time.Hour {
+		color = boldRed
+	}
+	return "due " + label, color
+}
+
+func humanDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}

--- a/cmd/due_test.go
+++ b/cmd/due_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDue(t *testing.T) {
+	// Friday, 2026-04-24 at 10:00 local.
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.Local)
+
+	tests := []struct {
+		in   string
+		want time.Time
+	}{
+		{"today", time.Date(2026, 4, 24, 0, 0, 0, 0, time.Local)},
+		{"today 4pm", time.Date(2026, 4, 24, 16, 0, 0, 0, time.Local)},
+		{"today 16:00", time.Date(2026, 4, 24, 16, 0, 0, 0, time.Local)},
+		{"tomorrow", time.Date(2026, 4, 25, 0, 0, 0, 0, time.Local)},
+		{"tomorrow 2pm", time.Date(2026, 4, 25, 14, 0, 0, 0, time.Local)},
+		{"tomorrow 2 pm", time.Date(2026, 4, 25, 14, 0, 0, 0, time.Local)},
+		{"tonight", time.Date(2026, 4, 24, 20, 0, 0, 0, time.Local)},
+		{"2026-04-30", time.Date(2026, 4, 30, 0, 0, 0, 0, time.Local)},
+		{"2026-04-30 14:00", time.Date(2026, 4, 30, 14, 0, 0, 0, time.Local)},
+		{"30.04.2026", time.Date(2026, 4, 30, 0, 0, 0, 0, time.Local)},
+		// Friday is today → Monday is 3 days out.
+		{"monday", time.Date(2026, 4, 27, 0, 0, 0, 0, time.Local)},
+		{"mon 9am", time.Date(2026, 4, 27, 9, 0, 0, 0, time.Local)},
+		// "next friday" when today is Friday → +7 days.
+		{"next friday", time.Date(2026, 5, 1, 0, 0, 0, 0, time.Local)},
+		// "friday" when today is Friday → today.
+		{"friday", time.Date(2026, 4, 24, 0, 0, 0, 0, time.Local)},
+		{"in 2h", now.Add(2 * time.Hour)},
+		{"in 30 minutes", now.Add(30 * time.Minute)},
+		{"+3d", now.Add(3 * 24 * time.Hour)},
+		{"2h", now.Add(2 * time.Hour)},
+		// Bare time before now → bumps to tomorrow.
+		{"8am", time.Date(2026, 4, 25, 8, 0, 0, 0, time.Local)},
+		// Bare time after now → today.
+		{"2pm", time.Date(2026, 4, 24, 14, 0, 0, 0, time.Local)},
+	}
+
+	for _, tc := range tests {
+		got, err := parseDueAt(tc.in, now)
+		if err != nil {
+			t.Errorf("parseDueAt(%q): unexpected error: %v", tc.in, err)
+			continue
+		}
+		if !got.Equal(tc.want) {
+			t.Errorf("parseDueAt(%q): got %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseDueErrors(t *testing.T) {
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.Local)
+	for _, in := range []string{"", "garbage", "25:99", "tomorrow 99pm"} {
+		if _, err := parseDueAt(in, now); err == nil {
+			t.Errorf("parseDueAt(%q): expected error, got nil", in)
+		}
+	}
+}

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+type listRow struct {
+	ID      string // pre-formatted (color/brackets)
+	NS      string // pre-formatted; empty string means "don't render this column"
+	Text    string // raw, wrapped at render time
+	Due     string // pre-formatted
+	Created string // pre-formatted
+	Done    string // pre-formatted, optional trailing suffix
+}
+
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+func visibleLen(s string) int {
+	return utf8.RuneCountInString(ansiRe.ReplaceAllString(s, ""))
+}
+
+func padVis(s string, width int) string {
+	diff := width - visibleLen(s)
+	if diff <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", diff)
+}
+
+// wrapText word-wraps s to at most width runes per line. Long single words
+// are hard-split. Empty input returns a single empty line.
+func wrapText(s string, width int) []string {
+	if width <= 0 {
+		return []string{s}
+	}
+	if utf8.RuneCountInString(s) <= width {
+		return []string{s}
+	}
+	var lines []string
+	var cur strings.Builder
+	curLen := 0
+	flush := func() {
+		if cur.Len() > 0 {
+			lines = append(lines, cur.String())
+			cur.Reset()
+			curLen = 0
+		}
+	}
+	for _, word := range strings.Fields(s) {
+		wLen := utf8.RuneCountInString(word)
+		if wLen > width {
+			flush()
+			// hard-split oversized words
+			runes := []rune(word)
+			for len(runes) > width {
+				lines = append(lines, string(runes[:width]))
+				runes = runes[width:]
+			}
+			cur.WriteString(string(runes))
+			curLen = len(runes)
+			continue
+		}
+		if curLen == 0 {
+			cur.WriteString(word)
+			curLen = wLen
+		} else if curLen+1+wLen <= width {
+			cur.WriteByte(' ')
+			cur.WriteString(word)
+			curLen += 1 + wLen
+		} else {
+			flush()
+			cur.WriteString(word)
+			curLen = wLen
+		}
+	}
+	flush()
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
+}
+
+// renderList prints rows as a padded, word-wrapped table. The text column
+// absorbs any slack so the overall line stays within lineWidth runes.
+func renderList(rows []listRow, lineWidth int) {
+	if len(rows) == 0 {
+		return
+	}
+	const (
+		leading = 2
+		gap     = 2
+		minText = 20
+	)
+
+	idW, nsW, dueW, createdW, doneW := 0, 0, 0, 0, 0
+	hasNS := false
+	for _, r := range rows {
+		if v := visibleLen(r.ID); v > idW {
+			idW = v
+		}
+		if r.NS != "" {
+			hasNS = true
+		}
+		if v := visibleLen(r.NS); v > nsW {
+			nsW = v
+		}
+		if v := visibleLen(r.Due); v > dueW {
+			dueW = v
+		}
+		if v := visibleLen(r.Created); v > createdW {
+			createdW = v
+		}
+		if v := visibleLen(r.Done); v > doneW {
+			doneW = v
+		}
+	}
+
+	// Width of everything except the text column itself.
+	fixedW := leading + idW + gap
+	if hasNS {
+		fixedW += nsW + gap
+	}
+	fixedW += gap + dueW + gap + createdW
+	if doneW > 0 {
+		fixedW += 1 + doneW
+	}
+
+	textW := lineWidth - fixedW
+	if textW < minText {
+		textW = minText
+	}
+
+	contPad := strings.Repeat(" ", leading+idW+gap)
+	if hasNS {
+		contPad += strings.Repeat(" ", nsW+gap)
+	}
+
+	for _, r := range rows {
+		lines := wrapText(r.Text, textW)
+
+		var b strings.Builder
+		b.WriteString(strings.Repeat(" ", leading))
+		b.WriteString(padVis(r.ID, idW))
+		b.WriteString(strings.Repeat(" ", gap))
+		if hasNS {
+			b.WriteString(padVis(r.NS, nsW))
+			b.WriteString(strings.Repeat(" ", gap))
+		}
+		b.WriteString(padVis(lines[0], textW))
+		b.WriteString(strings.Repeat(" ", gap))
+		b.WriteString(padVis(r.Due, dueW))
+		b.WriteString(strings.Repeat(" ", gap))
+		b.WriteString(padVis(r.Created, createdW))
+		if r.Done != "" {
+			b.WriteString(" ")
+			b.WriteString(r.Done)
+		}
+		fmt.Println(b.String())
+
+		for i := 1; i < len(lines); i++ {
+			fmt.Println(contPad + lines[i])
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,13 +3,43 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	"github.com/elvisoric/todo/store"
 	"github.com/spf13/cobra"
 )
+
+var sortBy string
+
+func init() {
+	rootCmd.Flags().StringVarP(&sortBy, "sort", "o", "", "Sort order: due (by due date; no-due items last by creation)")
+}
+
+func sortTodos(todos []store.Todo, by string) error {
+	switch by {
+	case "":
+		return nil
+	case "due":
+		sort.SliceStable(todos, func(i, j int) bool {
+			a, b := todos[i], todos[j]
+			switch {
+			case a.DueAt != nil && b.DueAt != nil:
+				return a.DueAt.Before(*b.DueAt)
+			case a.DueAt != nil:
+				return true
+			case b.DueAt != nil:
+				return false
+			default:
+				return a.CreatedAt.Before(b.CreatedAt)
+			}
+		})
+		return nil
+	default:
+		return fmt.Errorf("unknown sort order %q (supported: due)", by)
+	}
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "todo [space]",
@@ -18,6 +48,19 @@ var rootCmd = &cobra.Command{
 
 Run 'todo' to see default todos and all spaces.
 Run 'todo <space>' to see todos in that space (e.g. todo office).
+Add '--sort=due' to any listing to order by due date (items without a due
+date fall to the bottom, sorted by creation time).
+
+Due dates:
+  todo add "finish report" -d "tomorrow 2pm"
+  todo due <id> "next monday"
+  todo overdue              # items whose due date has passed
+  todo alarm                # items due within a configured window (or overdue)
+
+Configuration (YAML at $HOME/.config/todo/.todo, or $TODO_PATH):
+  general:
+    line_width: 120
+    alarm_window: 1h
 
 Shell Completion:
   Bash:  source <(todo completion bash)
@@ -41,9 +84,12 @@ func Execute() error {
 
 func init() {
 	rootCmd.AddCommand(addCmd)
+	rootCmd.AddCommand(alarmCmd)
 	rootCmd.AddCommand(doneCmd)
 	rootCmd.AddCommand(deleteCmd)
+	rootCmd.AddCommand(dueCmd)
 	rootCmd.AddCommand(listDoneCmd)
+	rootCmd.AddCommand(overdueCmd)
 	rootCmd.AddCommand(spacesCmd)
 	rootCmd.AddCommand(renameCmd)
 	rootCmd.AddCommand(moveCmd)
@@ -66,6 +112,9 @@ func runList(cmd *cobra.Command, args []string) error {
 			fmt.Printf("No todos in space %q.\n", space)
 			return nil
 		}
+		if err := sortTodos(todos, sortBy); err != nil {
+			return err
+		}
 		fmt.Printf("Todos in %s:\n", c(boldCyan, space))
 		printTodos(todos)
 		return nil
@@ -82,11 +131,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	if len(defaultTodos) == 0 {
 		fmt.Println(c(dim, "No todos in default space."))
 	} else {
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		for _, t := range defaultTodos {
-			fmt.Fprintf(w, "  %s\t%s\t%s\n", c(yellow, "["+t.ID+"]"), t.Text, c(dim, fmtTime(t.CreatedAt)))
+		if err := sortTodos(defaultTodos, sortBy); err != nil {
+			return err
 		}
-		w.Flush()
+		renderList(todoRows(defaultTodos, false), getConfig().General.LineWidth)
 	}
 
 	// Show other spaces with counts
@@ -124,39 +172,40 @@ func printTree(n *store.NamespaceNode, indent string) {
 	}
 }
 
-func printTodosByNamespace(s *store.Store, ns, label string) {
-	var todos []store.Todo
-	for _, t := range s.ActiveTodos() {
-		if t.Namespace == ns {
-			todos = append(todos, t)
-		}
-	}
-	if len(todos) == 0 {
-		return
-	}
-	fmt.Printf("%s %s %s\n", c(dim, "──"), c(boldCyan, label), c(dim, "──"))
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	for _, t := range todos {
-		fmt.Fprintf(w, "  %s\t%s\t%s\n", c(yellow, "["+t.ID+"]"), t.Text, c(dim, fmtTime(t.CreatedAt)))
-	}
-	w.Flush()
-	fmt.Println()
-}
-
 func printTodos(todos []store.Todo) {
 	if len(todos) == 0 {
 		return
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	renderList(todoRows(todos, true), getConfig().General.LineWidth)
+}
+
+func todoRows(todos []store.Todo, showNS bool) []listRow {
+	now := time.Now()
+	rows := make([]listRow, 0, len(todos))
 	for _, t := range todos {
-		ts := c(dim, fmtTime(t.CreatedAt))
-		doneTS := ""
-		if t.DoneAt != nil {
-			doneTS = c(green, " (done "+fmtTime(*t.DoneAt)+")")
+		r := listRow{
+			ID:      c(yellow, "["+t.ID+"]"),
+			Text:    t.Text,
+			Due:     dueCell(t, now),
+			Created: c(dim, fmtTime(t.CreatedAt)),
 		}
-		fmt.Fprintf(w, "  %s\t%s\t%s\t%s%s\n", c(yellow, "["+t.ID+"]"), c(magenta, t.Namespace), t.Text, ts, doneTS)
+		if showNS {
+			r.NS = c(magenta, t.Namespace)
+		}
+		if t.DoneAt != nil {
+			r.Done = c(green, "(done "+fmtTime(*t.DoneAt)+")")
+		}
+		rows = append(rows, r)
 	}
-	w.Flush()
+	return rows
+}
+
+func dueCell(t store.Todo, now time.Time) string {
+	if t.DueAt == nil {
+		return ""
+	}
+	label, color := formatDue(*t.DueAt, now)
+	return c(color, label)
 }
 
 func fmtTime(t time.Time) string {
@@ -164,29 +213,55 @@ func fmtTime(t time.Time) string {
 }
 
 // --- add ---
-var addNamespace string
+var (
+	addNamespace string
+	addDue       string
+)
 
 var addCmd = &cobra.Command{
 	Use:   "add [text]",
 	Short: "Add a new todo",
-	Args:  cobra.MinimumNArgs(1),
+	Long: `Add a new todo. Use -d to set a due date.
+
+Due-date examples:
+  todo add "call mom" -d "tomorrow 2pm"
+  todo add "finish report" -d "today 16:00"
+  todo add "write letter" -d "next monday"
+  todo add "ship feature" -d "2026-04-30 14:00"
+  todo add "drink water" -d "in 2h"
+  todo add "weekly sync" -d friday`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		text := strings.Join(args, " ")
+		var due *time.Time
+		if addDue != "" {
+			t, err := ParseDue(addDue)
+			if err != nil {
+				return err
+			}
+			due = &t
+		}
 		s, err := store.Load()
 		if err != nil {
 			return err
 		}
-		t := s.Add(text, addNamespace)
+		t := s.Add(text, addNamespace, due)
 		if err := s.Save(); err != nil {
 			return err
 		}
-		fmt.Printf("%s %s to %s: %s\n", c(boldGreen, "+"), c(yellow, "["+t.ID+"]"), c(cyan, t.Namespace), t.Text)
+		msg := fmt.Sprintf("%s %s to %s: %s", c(boldGreen, "+"), c(yellow, "["+t.ID+"]"), c(cyan, t.Namespace), t.Text)
+		if due != nil {
+			label, color := formatDue(*due, time.Now())
+			msg += " " + c(color, "("+label+")")
+		}
+		fmt.Println(msg)
 		return nil
 	},
 }
 
 func init() {
 	addCmd.Flags().StringVarP(&addNamespace, "space", "s", "", "Topic/space (dot-separated, e.g. office.monday)")
+	addCmd.Flags().StringVarP(&addDue, "due", "d", "", "Due date (e.g. \"tomorrow 2pm\", \"2026-04-30\", \"next monday\", \"in 3h\")")
 }
 
 // --- done ---
@@ -330,6 +405,117 @@ var spacesCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// --- due ---
+var dueClear bool
+
+var dueCmd = &cobra.Command{
+	Use:   "due [id] [date...]",
+	Short: "Set or clear the due date of a todo",
+	Long: `Set the due date of an existing todo.
+
+Examples:
+  todo due abcd "next friday"
+  todo due abcd tomorrow 2pm
+  todo due abcd 2026-04-30 14:00
+  todo due abcd --clear`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if dueClear {
+			if len(args) != 1 {
+				return fmt.Errorf("--clear requires exactly one id")
+			}
+			return nil
+		}
+		if len(args) < 2 {
+			return fmt.Errorf("expected <id> and a date (or use --clear)")
+		}
+		return nil
+	},
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return completeTodoIDs(toComplete, false)
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		s, err := store.Load()
+		if err != nil {
+			return err
+		}
+		t := s.FindByID(id)
+		if t == nil {
+			return fmt.Errorf("todo %s not found", id)
+		}
+		if dueClear {
+			t.DueAt = nil
+			if err := s.Save(); err != nil {
+				return err
+			}
+			fmt.Printf("%s %s due date cleared.\n", c(boldGreen, "✓"), c(yellow, "["+t.ID+"]"))
+			return nil
+		}
+		expr := strings.Join(args[1:], " ")
+		when, err := ParseDue(expr)
+		if err != nil {
+			return err
+		}
+		t.DueAt = &when
+		if err := s.Save(); err != nil {
+			return err
+		}
+		label, color := formatDue(when, time.Now())
+		fmt.Printf("%s %s %s\n", c(boldGreen, "✓"), c(yellow, "["+t.ID+"]"), c(color, label))
+		return nil
+	},
+}
+
+func init() {
+	dueCmd.Flags().BoolVar(&dueClear, "clear", false, "Clear the due date instead of setting it")
+}
+
+// --- overdue ---
+var overdueAll bool
+
+var overdueCmd = &cobra.Command{
+	Use:   "overdue",
+	Short: "List todos whose due date has passed",
+	Long:  "List active todos whose due date has passed. Defaults to the default space; use --all for every space.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s, err := store.Load()
+		if err != nil {
+			return err
+		}
+		now := time.Now()
+		var overdue []store.Todo
+		for _, t := range s.ActiveTodos() {
+			if t.DueAt == nil || !t.DueAt.Before(now) {
+				continue
+			}
+			if !overdueAll && t.Namespace != "default" {
+				continue
+			}
+			overdue = append(overdue, t)
+		}
+		if len(overdue) == 0 {
+			fmt.Println(c(dim, "No overdue todos."))
+			return nil
+		}
+		sort.SliceStable(overdue, func(i, j int) bool {
+			return overdue[i].DueAt.Before(*overdue[j].DueAt)
+		})
+		if overdueAll {
+			printTodos(overdue)
+			return nil
+		}
+		renderList(todoRows(overdue, false), getConfig().General.LineWidth)
+		return nil
+	},
+}
+
+func init() {
+	overdueCmd.Flags().BoolVar(&overdueAll, "all", false, "Include overdue todos from every space, not just default")
 }
 
 // --- list-done ---

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,7 +57,7 @@ Due dates:
   todo overdue              # items whose due date has passed
   todo alarm                # items due within a configured window (or overdue)
 
-Configuration (YAML at $HOME/.config/todo/.todo, or $TODO_PATH):
+Configuration (YAML at $HOME/.todo/config.yaml, or $TODO_PATH):
   general:
     line_width: 120
     alarm_window: 1h

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.10.2
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/store/store.go
+++ b/store/store.go
@@ -15,12 +15,13 @@ import (
 const defaultNamespace = "default"
 
 type Todo struct {
-	ID        string    `json:"id"`
-	Text      string    `json:"text"`
-	Namespace string    `json:"namespace"`
-	Done      bool      `json:"done"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        string     `json:"id"`
+	Text      string     `json:"text"`
+	Namespace string     `json:"namespace"`
+	Done      bool       `json:"done"`
+	CreatedAt time.Time  `json:"created_at"`
 	DoneAt    *time.Time `json:"done_at,omitempty"`
+	DueAt     *time.Time `json:"due_at,omitempty"`
 }
 
 type Store struct {
@@ -86,7 +87,7 @@ func (s *Store) existingIDs() map[string]bool {
 	return m
 }
 
-func (s *Store) Add(text, namespace string) Todo {
+func (s *Store) Add(text, namespace string, due *time.Time) Todo {
 	if namespace == "" {
 		namespace = defaultNamespace
 	}
@@ -95,6 +96,7 @@ func (s *Store) Add(text, namespace string) Todo {
 		Text:      text,
 		Namespace: namespace,
 		CreatedAt: time.Now(),
+		DueAt:     due,
 	}
 	s.Todos = append(s.Todos, t)
 	return t


### PR DESCRIPTION
- todo add -d: natural-language due dates (tomorrow 2pm, next monday,
  in 3h, 2026-04-30 14:00, etc.)
- todo due <id>: set/update/--clear due date on an existing todo
- todo overdue [--all]: list todos past their due date
- todo alarm: list todos overdue or due within a configurable window
  (--within, --format pretty|plain, --space)
- --sort=due on listings: order by due date, no-due items last
- YAML config at $HOME/.config/todo/.todo or $TODO_PATH with
  general.line_width (default 120) and general.alarm_window (default 1h)
- Text column wraps at line_width; continuation lines align under text